### PR TITLE
Fix argument requirement in getopt_long

### DIFF
--- a/main.c
+++ b/main.c
@@ -40,7 +40,7 @@ int main(int argc, char *argv[]) {
     int flags = 0;
 
     int c = 0;
-    while ((c = getopt_long(argc, argv, "f:e:pmst", options, NULL)) != -1) {
+    while ((c = getopt_long(argc, argv, "fepmst", options, NULL)) != -1) {
         switch (c) {
             case 'p':
                 flags |= FLAG_PRETTY_PRINT;


### PR DESCRIPTION
It seems at least `-f` required an argument some time ago, but when `no_argument` was put inside the `struct option[]`, the semi-colon `:` in the call to `getopt_long` (indicating that an argument is expected) should have been removed.